### PR TITLE
Allow sharing editing access to a survey via Collaboration

### DIFF
--- a/app/assets/javascripts/collaborations.coffee
+++ b/app/assets/javascripts/collaborations.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/collaborations.scss
+++ b/app/assets/stylesheets/collaborations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the collaborations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,12 +12,12 @@ class ApplicationController < ActionController::Base
 
   def authenticate_user!
     unless current_user
-      render plain: 'Access Denied.', status: 403
+      redirect_to new_session_path, alert: "Please log in"
     end
   end
 
-  def authorize(controller, action)
-    unless current_permission.allow?(controller, action)
+  def authorize(resource)
+    unless current_permission.allow?(controller_name, action_name, resource)
       redirect_to root_path, alert: "Insufficient Permission."
     end
   end

--- a/app/controllers/collaborations_controller.rb
+++ b/app/controllers/collaborations_controller.rb
@@ -1,0 +1,33 @@
+class CollaborationsController < ApplicationController
+  def index
+    load_survey
+    @collaboration = Collaboration.new
+  end
+
+  def create
+    load_survey
+    @collaboration = Collaboration.new collaboration_params
+    @collaboration.survey = @survey
+    if @collaboration.save
+      redirect_to survey_collaborations_path(@survey), alert: "Added #{@collaboration.email}"
+    else
+      flash.now[:error] = "Error: #{@collaboration.errors.full_messages.to_sentence}"
+      render 'index'
+    end
+  end
+
+  def destroy
+    @collaboration = Collaboration.find params[:id]
+    @collaboration.destroy
+    redirect_to survey_collaborations_path(@collaboration.survey_id)
+  end
+
+  private
+  def load_survey
+    @survey = Survey.find params[:survey_id]
+  end
+
+  def collaboration_params
+    params.require(:collaboration).permit(:user_id, :role)
+  end
+end

--- a/app/controllers/collaborations_controller.rb
+++ b/app/controllers/collaborations_controller.rb
@@ -1,4 +1,6 @@
 class CollaborationsController < ApplicationController
+  before_action :authenticate_user!
+
   def index
     load_survey
     @collaboration = Collaboration.new

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -30,7 +30,7 @@ class ResponsesController < ApplicationController
     @form = ResponseForm.new(response)
     if @form.validate params[:response].to_hash
       @form.save
-      redirect_to edit_survey_response_path(@form.survey, @form), notice: "Saved."
+      redirect_to root_path, notice: "Thank you!"
     else
       render 'edit'
     end

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -16,6 +16,7 @@ class SurveysController < ApplicationController
   def create
     build_survey_form
     if @form.save
+      @form.create_owner!(current_user)
       redirect_to edit_survey_path(@form)
     else
       render 'new'
@@ -23,8 +24,8 @@ class SurveysController < ApplicationController
   end
 
   def edit
-    authorize controller_name, action_name
     load_survey_form
+    authorize @form.model
     @form.prepopulate!
   end
 

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -2,7 +2,7 @@ class SurveysController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index]
 
   def index
-    @surveys = Survey.all
+    @surveys = AccessibleSurvey.new(current_user).all
   end
 
   def new

--- a/app/forms/question_form.rb
+++ b/app/forms/question_form.rb
@@ -17,6 +17,7 @@ class QuestionForm < Reform::Form
     case type.to_sym
     when :short_answer
       # don't add choices
+      self.choices << Choice.new if choices.length == 0
     else
       # always add an extra choice to render
       self.choices << Choice.new

--- a/app/forms/survey_form.rb
+++ b/app/forms/survey_form.rb
@@ -1,6 +1,7 @@
 class SurveyForm < Reform::Form
   property :title
   validates :title, presence: true
+  delegate :create_owner!, to: :model
 
   collection :questions,
     skip_if: :skip_blank_questions,

--- a/app/helpers/collaborations_helper.rb
+++ b/app/helpers/collaborations_helper.rb
@@ -1,0 +1,2 @@
+module CollaborationsHelper
+end

--- a/app/models/accessible_survey.rb
+++ b/app/models/accessible_survey.rb
@@ -1,0 +1,10 @@
+class AccessibleSurvey < Struct.new(:user)
+  def all
+    return [] unless user
+    if user.admin?
+      Survey.all
+    else
+      Survey.where(id: Collaboration.where(user: user).pluck(:survey_id))
+    end
+  end
+end

--- a/app/models/collaboration.rb
+++ b/app/models/collaboration.rb
@@ -5,7 +5,13 @@ class Collaboration < ApplicationRecord
   validates :survey, :user, :role, presence: true
   enum role: { owner: 0, editor: 1, viewer: 2 }
   validates :role, inclusion: {in: roles.keys }
-  validates :role, uniqueness: {scope: :user_id, message: "already exists for user"}
+  validates :role, uniqueness: {scope: [:user_id, :survey_id], message: "already exists for user and survey"}
+
+  SURVEY_ACTIONS = {
+    owner: %w(new create show edit update destroy),
+    editor: %w(new create show edit update destroy),
+    viewer: %w(show)
+  }
 
   def email
     user.try(:email)

--- a/app/models/collaboration.rb
+++ b/app/models/collaboration.rb
@@ -1,0 +1,13 @@
+class Collaboration < ApplicationRecord
+  belongs_to :survey
+  belongs_to :user
+
+  validates :survey, :user, :role, presence: true
+  enum role: { owner: 0, editor: 1, viewer: 2 }
+  validates :role, inclusion: {in: roles.keys }
+  validates :role, uniqueness: {scope: :user_id, message: "already exists for user"}
+
+  def email
+    user.try(:email)
+  end
+end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -3,8 +3,13 @@ class Permission < Struct.new(:user)
     "admin" => ["surveys#new", "surveys#create", "surveys#edit", "surveys#update", "surveys#destroy"],
     "user" => ["surveys#new", "surveys#create"]
   }
-  def allow?(controller, action)
-    right = "#{controller}##{action}"
-    LOOKUP[user.role] && LOOKUP[user.role].include?(right)
+  def allow?(controller, action, resource = nil)
+    if resource
+      # TODO: handle resource better
+      resource.allow_collaboration?(user, action)
+    else
+      right = "#{controller}##{action}"
+      LOOKUP[user.role] && LOOKUP[user.role].include?(right)
+    end
   end
 end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -1,6 +1,7 @@
 class Survey < ApplicationRecord
   has_many :responses, dependent: :destroy
   has_many :questions, dependent: :destroy
+  has_many :collaborations, dependent: :destroy
 
   validates :title, presence: true
 

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -12,4 +12,14 @@ class Survey < ApplicationRecord
   def last_response_at
     responses.order(updated_at: :desc).first.try(:updated_at)
   end
+
+  def create_owner!(user)
+    collaborations.create! user: user, role: :owner
+  end
+
+  def allow_collaboration?(user, action)
+    if role = collaborations.find_by(user: user).try(:role)
+      Collaboration::SURVEY_ACTIONS[role.to_sym].include?(action)
+    end
+  end
 end

--- a/app/views/collaborations/index.html.erb
+++ b/app/views/collaborations/index.html.erb
@@ -1,0 +1,35 @@
+<h1>Sharing Settings</h1>
+
+<div class="card">
+  <div class="card-header">
+    <h3 class="card-title">Add A Collaborator</h3>
+  </div>
+  <div class="card-block">
+    <%= form_for [@survey, @collaboration] do |f| %>
+      <div class="form-inline">
+      <%= f.select :user_id, User.all.map{|e| [e.email, e.id]}, {}, class: 'form-control' %>
+      <%= f.select :role, Collaboration.roles.keys, {}, class: 'form-control' %>
+      <%= f.submit "Add", class: 'btn btn-secondary' %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<table class="table table-bordered table-striped">
+  <thead class="thead thead-default">
+    <th>Email</th>
+    <th>Role</th>
+    <th>Actions</th>
+  </thead>
+  <tbody>
+    <% @survey.collaborations.each do |collab| %>
+      <tr>
+        <td><%= collab.email %></td>
+        <td><%= collab.role %></td>
+        <td><%= link_to "Delete", collab, class: 'btn btn-sm btn-secondary', method: 'delete' %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+

--- a/app/views/responses/_question.html.erb
+++ b/app/views/responses/_question.html.erb
@@ -6,4 +6,3 @@
     <%= render "responses/question_body/#{question.type}", question: question, f: f %>
   </div>
 </div>
-

--- a/app/views/surveys/_choice_field_short_answer.html.erb
+++ b/app/views/surveys/_choice_field_short_answer.html.erb
@@ -1,4 +1,4 @@
 <div class="form-group form-inline">
-  <input type="text" placeholder="Short answer text" class="form-control"/>
+  <input type="text" placeholder="Short answer text" class="form-control" disabled/>
   <%= fc.hidden_field :content, value: 'SHORT_ANSWER_INVISIBLE_LABEL:' %>
 </div>

--- a/app/views/surveys/edit.html.erb
+++ b/app/views/surveys/edit.html.erb
@@ -1,6 +1,7 @@
 <h1>
   Questions |
-  <%= link_to "Responses", survey_responses_path(@form) %>
+  <%= link_to "Responses", survey_responses_path(@form) %> |
+  <%= link_to "Take", new_survey_response_path(@form) %>
 </h1>
 
 <%= form_for @form do |f| %>

--- a/app/views/surveys/index.html.erb
+++ b/app/views/surveys/index.html.erb
@@ -16,9 +16,10 @@
         <td><%= link_to survey.title || "No title", survey %></td>
         <td><%= pluralize survey.responses_count, 'response' %></td>
         <td>
-          <%= link_to 'View', survey, class: 'btn btn-secondary' %>
-          <%= link_to 'Edit', edit_survey_path(survey), class: 'btn btn-secondary' %>
-          <%= link_to 'Responses', survey_responses_path(survey), class: 'btn btn-secondary' %>
+          <%= link_to 'View', survey, class: 'btn btn-sm btn-secondary' %>
+          <%= link_to 'Edit', edit_survey_path(survey), class: 'btn btn-sm btn-secondary' %>
+          <%= link_to 'Responses', survey_responses_path(survey), class: 'btn btn-sm btn-secondary' %>
+          <%= link_to 'Collaborators', survey_collaborations_path(survey), class: 'btn btn-sm btn-secondary' %>
         </td>
         <td><%= time_ago_in_words survey.updated_at %></td>
         <td><%= time_ago_in_words(survey.last_response_at) if survey.last_response_at %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,11 @@
 Rails.application.routes.draw do
+  resources :collaborations, only: [:destroy]
+
   resources :choices, only: [:destroy]
   resources :questions, only: [:destroy]
   resources :surveys do
     resources :responses
+    resources :collaborations
   end
   resources :sessions, only: [:new, :create]
   delete 'logout' => 'sessions#destroy'

--- a/db/migrate/20160728042324_create_collaborations.rb
+++ b/db/migrate/20160728042324_create_collaborations.rb
@@ -1,0 +1,11 @@
+class CreateCollaborations < ActiveRecord::Migration[5.0]
+  def change
+    create_table :collaborations do |t|
+      t.references :survey, foreign_key: true
+      t.references :user, foreign_key: true
+      t.integer :role
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160725013854) do
+ActiveRecord::Schema.define(version: 20160728042324) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,16 @@ ActiveRecord::Schema.define(version: 20160725013854) do
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
     t.index ["question_id"], name: "index_choices_on_question_id", using: :btree
+  end
+
+  create_table "collaborations", force: :cascade do |t|
+    t.integer  "survey_id"
+    t.integer  "user_id"
+    t.integer  "role"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["survey_id"], name: "index_collaborations_on_survey_id", using: :btree
+    t.index ["user_id"], name: "index_collaborations_on_user_id", using: :btree
   end
 
   create_table "questions", force: :cascade do |t|
@@ -78,6 +88,8 @@ ActiveRecord::Schema.define(version: 20160725013854) do
   add_foreign_key "answers", "questions"
   add_foreign_key "answers", "responses"
   add_foreign_key "choices", "questions"
+  add_foreign_key "collaborations", "surveys"
+  add_foreign_key "collaborations", "users"
   add_foreign_key "questions", "surveys"
   add_foreign_key "resources", "surveys"
   add_foreign_key "responses", "surveys"

--- a/spec/controllers/collaborations_controller_spec.rb
+++ b/spec/controllers/collaborations_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CollaborationsController, type: :controller do
+
+end

--- a/spec/features/surveys_spec.rb
+++ b/spec/features/surveys_spec.rb
@@ -16,8 +16,7 @@ RSpec.describe "Surveys", type: :feature do
     it "denies access for guests" do
       visit '/surveys/new'
       # save_and_open_page
-      expect(page).to have_content("Access Denied.")
-      expect(page.status_code).to eq 403
+      expect(page).to have_content("Please log in")
     end
 
     it "allows users" do

--- a/spec/helpers/collaborations_helper_spec.rb
+++ b/spec/helpers/collaborations_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the CollaborationsHelper. For example:
+#
+# describe CollaborationsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe CollaborationsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/collaboration_spec.rb
+++ b/spec/models/collaboration_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Collaboration, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Merging in some code we did in last week's lab:

- [x] Add Collaboration model with 3 types of access: owner, editor and viewer
- [x] Check to make sure editor and owner of a survey can edit that survey, and deny access otherwise
- [x] Provide UI to add collaborators to a survey
- [x] After a user creates a survey, a collaboration record is also created to indicates the user's ownership of the survey