### PR TITLE
Pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,3 +57,4 @@ gem "reform"
 gem "reform-rails"
 gem 'faker', '~> 1.6', '>= 1.6.6'
 gem 'chartkick', '~> 2.0', '>= 2.0.1'
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,9 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    kaminari (0.17.0)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     listen (3.0.8)
@@ -253,6 +256,7 @@ DEPENDENCIES
   guard-rspec
   jbuilder (~> 2.5)
   jquery-rails
+  kaminari
   launchy
   listen (~> 3.0.5)
   pg (~> 0.18)

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -2,6 +2,11 @@ class ResponsesController < ApplicationController
   def index
     load_survey
     @responses = @survey.responses.page(params[:page]).per(params[:per])
+
+    respond_to do |format|
+      format.html
+      format.js
+    end
   end
 
   def new

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -1,6 +1,7 @@
 class ResponsesController < ApplicationController
   def index
     load_survey
+    @responses = @survey.responses.page(params[:page]).per(params[:per])
   end
 
   def new

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, { remote: remote, class: 'page-link' } %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,15 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/responses/_responses.html.erb
+++ b/app/views/responses/_responses.html.erb
@@ -1,0 +1,32 @@
+<%= paginate responses, remote: true %>
+<table class="table table-sm table-bordered table-striped">
+  <thead>
+    <tr>
+      <th>#</th>
+      <% survey.questions.each do |question| %>
+        <th><%= question.title %></th>
+      <% end %>
+    </tr>
+  </thead>
+  <tbody>
+    <% responses.each do |response| %>
+      <tr>
+        <td><%= response.id %></td>
+        <% survey.questions.each do |question| %>
+          <td>
+            <% question.choices.each do |choice| %>
+              <div>
+                <% response.answers_for(question: question, choice: choice).each do |answer| %>
+                  <span data-answer-id="<%= answer.id %>">
+                    <%= answer.content %>
+                  </span>
+                <% end %>
+              </div>
+            <% end %>
+          </td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<%= paginate responses, remote: true %>

--- a/app/views/responses/index.html.erb
+++ b/app/views/responses/index.html.erb
@@ -4,35 +4,6 @@
   <%= link_to "New Response", new_survey_response_path(@survey), class: 'btn btn-secondary' %>
 </p>
 
-<%= paginate @responses %>
-<table class="table table-sm table-bordered table-striped">
-  <thead>
-    <tr>
-      <th>#</th>
-      <% @survey.questions.each do |question| %>
-        <th><%= question.title %></th>
-      <% end %>
-    </tr>
-  </thead>
-  <tbody>
-    <% @responses.each do |response| %>
-      <tr>
-        <td><%= response.id %></td>
-        <% @survey.questions.each do |question| %>
-          <td>
-            <% question.choices.each do |choice| %>
-              <div>
-                <% response.answers_for(question: question, choice: choice).each do |answer| %>
-                  <span data-answer-id="<%= answer.id %>">
-                    <%= answer.content %>
-                  </span>
-                <% end %>
-              </div>
-            <% end %>
-          </td>
-        <% end %>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
-<%= paginate @responses %>
+<div class="responses-wrapper">
+  <%= render "responses", survey: @survey, responses: @responses %>
+</div>

--- a/app/views/responses/index.html.erb
+++ b/app/views/responses/index.html.erb
@@ -4,6 +4,7 @@
   <%= link_to "New Response", new_survey_response_path(@survey), class: 'btn btn-secondary' %>
 </p>
 
+<%= paginate @responses %>
 <table class="table table-sm table-bordered table-striped">
   <thead>
     <tr>
@@ -14,7 +15,7 @@
     </tr>
   </thead>
   <tbody>
-    <% @survey.responses.each do |response| %>
+    <% @responses.each do |response| %>
       <tr>
         <td><%= response.id %></td>
         <% @survey.questions.each do |question| %>
@@ -34,5 +35,4 @@
     <% end %>
   </tbody>
 </table>
-
-
+<%= paginate @responses %>

--- a/app/views/responses/index.js.erb
+++ b/app/views/responses/index.js.erb
@@ -1,0 +1,1 @@
+$(".responses-wrapper").html("<%= j render 'responses', survey: @survey, responses: @responses %>");


### PR DESCRIPTION
naturally, `/responses` page cannot display too many results.

- [x] add pagination using kaminari and use bootstrap4 template at https://github.com/amatsuda/kaminari_themes/tree/master/bootstrap4
- [x] support `remote: true` option so that we can switch between pages instantly:

![](https://dl.dropboxusercontent.com/spa/vkwvskbavc27sn4/pagination-ajax.gif)